### PR TITLE
Compatibility with Gentoo installation.

### DIFF
--- a/scripts/do_stir.sh
+++ b/scripts/do_stir.sh
@@ -3,7 +3,7 @@
 start=$(/bin/date  +%Y-%m-%d-%H%M%S)
 start_s=$(/bin/date +%s)
 
-/usr/bin/time -p /home/hbarta/bin/stir_pool.sh >"/home/hbarta/logs/$start.stir_pools.txt" 2>&1
+time -p /home/hbarta/bin/stir_pool.sh >"/home/hbarta/logs/$start.stir_pools.txt" 2>&1
 
 finish_s=$(/bin/date +%s)
 elapsed=$((finish_s-start_s))

--- a/scripts/thrash_syncoid.sh
+++ b/scripts/thrash_syncoid.sh
@@ -15,7 +15,7 @@ do
     do_syncoid.sh
     
     # And check for corruption
-    for log in $(find /home/hbarta/logs -L -type f|sort|tail)
+    for log in $(find -L /home/hbarta/logs -type f|sort|tail)
     do
         if ( grep -q "use '-v' for a list" "$log" )
         then

--- a/scripts/thrash_zfs.sh
+++ b/scripts/thrash_zfs.sh
@@ -16,7 +16,7 @@ do
     time -p do_stir.sh
 
     # And check for corruption
-    for log in $(find /home/hbarta/logs -L -type f|sort|tail)
+    for log in $(find -L /home/hbarta/logs -type f|sort|tail)
     do
         if ( grep -q "use '-v' for a list" "$log" )
         then


### PR DESCRIPTION
It looks like 'find -L' options is context dependend and 'time' is bash builtin which doesn't exist separately in my installation.